### PR TITLE
feat:增加移除事件方法remove()

### DIFF
--- a/lib/pureFullPage.js
+++ b/lib/pureFullPage.js
@@ -44,7 +44,7 @@ class PureFullPage {
     this.currentPosition = -(activeNavIndex * this.viewHeight);
     this.turnPage(this.currentPosition);
   }
-  handleWindowResize(event) {
+  handleWindowResize = (event) => {
     // 设置防抖动函数
     utils.debounce(this.getNewPosition, this, event, this.DELAY);
   }
@@ -143,6 +143,16 @@ class PureFullPage {
       this.goUp();
     }
   }
+  
+  handleMouseWheel = null
+  handleTouchEnd = null
+  handleTouchStart = (event) => {
+    this.startY = event.touches[0].pageY
+  }
+  handleTouchMove = (event) => {
+    event.preventDefault()
+  }
+
   // 初始化函数
   init() {
     this.container.style.height = `${this.viewHeight}px`;
@@ -150,28 +160,42 @@ class PureFullPage {
     if (this.options.isShowNav) {
       this.createNav();
     }
-    // 设置截流函数
-    const handleMouseWheel = utils.throttle(this.scrollMouse, this, this.DELAY);
+
+    // 设置节流函数
+    this.handleMouseWheel = utils.throttle(this.scrollMouse, this, this.DELAY);
 
     // 鼠标滚轮监听，火狐鼠标滚动事件不同其他
     if (navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
-      document.addEventListener('mousewheel', handleMouseWheel);
+      document.addEventListener('mousewheel', this.handleMouseWheel);
     } else {
-      document.addEventListener('DOMMouseScroll', handleMouseWheel);
+      document.addEventListener('DOMMouseScroll', this.handleMouseWheel);
     }
 
     // 手机触屏屏幕
-    document.addEventListener('touchstart', event => {
-      this.startY = event.touches[0].pageY;
-    });
-    const handleTouchEnd = utils.throttle(this.touchEnd, this, 500);
-    document.addEventListener('touchend', handleTouchEnd);
-    document.addEventListener('touchmove', event => {
-      event.preventDefault();
-    });
+    document.addEventListener('touchstart', this.handleTouchStart);
+    this.handleTouchEnd = utils.throttle(this.touchEnd, this, 500);
+    document.addEventListener('touchend', this.handleTouchEnd);
+    document.addEventListener('touchmove', this.handleTouchMove);
 
     // 窗口尺寸变化时重置位置
-    window.addEventListener('resize', this.handleWindowResize.bind(this));
+    window.addEventListener('resize', this.handleWindowResize);
+  }
+  // 移除事件
+  remove() {
+    // 鼠标滚轮监听，火狐鼠标滚动事件不同其他
+    if (navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
+      document.removeEventListener('mousewheel', this.handleMouseWheel);
+    } else {
+      document.removeEventListener('DOMMouseScroll', this.handleMouseWheel);
+    }
+
+    // 手机触屏屏幕
+    document.removeEventListener('touchstart', this.handleTouchStart);
+    document.removeEventListener('touchend', this.handleTouchEnd);
+    document.removeEventListener('touchmove', this.handleTouchMove);
+
+    // 窗口尺寸变化时重置位置
+    window.removeEventListener('resize', this.handleWindowResize);
   }
 }
 

--- a/lib/pureFullPage.js
+++ b/lib/pureFullPage.js
@@ -144,13 +144,13 @@ class PureFullPage {
     }
   }
   
-  handleMouseWheel = null
-  handleTouchEnd = null
+  handleMouseWheel = null;
+  handleTouchEnd = null;
   handleTouchStart = (event) => {
-    this.startY = event.touches[0].pageY
+    this.startY = event.touches[0].pageY;
   }
   handleTouchMove = (event) => {
-    event.preventDefault()
+    event.preventDefault();
   }
 
   // 初始化函数

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ const pureFullPage = new PureFullPage({
   definePages: addAnimation,
 });
 
-pureFullPage.init()
+pureFullPage.init();
 
 
 // 离开页面时移除事件

--- a/readme.md
+++ b/readme.md
@@ -93,10 +93,16 @@ new PureFullPage();
 When instantiating pureFullPage, an object is accepted as a parameter, which can control whether to display the right navigation (It often does not need the right navigation on mobile) and custom page animation. The sample code is as follows:
 
 ```js
-new PureFullPage({
+const pureFullPage = new PureFullPage({
   isShowNav: true,
   definePages: addAnimation,
 });
+
+pureFullPage.init()
+
+
+// 离开页面时移除事件
+// pureFullPage.remove()
 ```
 
 | param name    | type     | default value | definition                                                                                                                                                                                                       |

--- a/src/js/pureFullPage.js
+++ b/src/js/pureFullPage.js
@@ -140,6 +140,15 @@ class PureFullPage {
       this.goUp();
     }
   }
+
+  handleMouseWheel = null;
+  handleNewPosition = null;
+  handleTouchStart = (event) => {
+    this.startY = event.touches[0].pageY;
+  }
+  handleTouchMove = (event) => {
+    event.preventDefault();
+  }
   // 初始化函数
   init() {
     this.container.style.height = `${this.viewHeight}px`;
@@ -149,25 +158,41 @@ class PureFullPage {
     }
 
     // 鼠标滚轮监听，火狐鼠标滚动事件不同其他
-    const handleMouseWheel = utils.debounce(this.scrollMouse.bind(this), 40, true);
+    this.handleMouseWheel = utils.debounce(this.scrollMouse.bind(this), 40, true);
     if (navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
-      document.addEventListener('mousewheel', handleMouseWheel);
+      document.addEventListener('mousewheel', this.handleMouseWheel);
     } else {
-      document.addEventListener('DOMMouseScroll', handleMouseWheel);
+      document.addEventListener('DOMMouseScroll', this.handleMouseWheel);
     }
 
     // 手机触屏屏幕
-    document.addEventListener('touchstart', event => {
-      this.startY = event.touches[0].pageY;
-    });
-    const handleTouchEnd = utils.throttle(this.touchEnd, this, 500);
-    document.addEventListener('touchend', handleTouchEnd);
-    document.addEventListener('touchmove', event => {
-      event.preventDefault();
-    });
+    document.addEventListener('touchstart', this.handleTouchStart);
+    this.handleTouchEnd = utils.throttle(this.touchEnd, this, 500);
+    document.addEventListener('touchend', this.handleTouchEnd);
+    document.addEventListener('touchmove', this.handleTouchMove);
 
     // 窗口尺寸变化时重置位置
-    const handleNewPosition = utils.debounce(this.getNewPosition.bind(this), 200);
-    window.addEventListener('resize', handleNewPosition);
+    this.handleNewPosition = utils.debounce(this.getNewPosition.bind(this), 200);
+    window.addEventListener('resize', this.handleNewPosition);
+  }
+  // 移除事件
+  remove() {
+    // 鼠标滚轮监听，火狐鼠标滚动事件不同其他
+    this.handleMouseWheel = utils.debounce(this.scrollMouse.bind(this), 40, true);
+    if (navigator.userAgent.toLowerCase().indexOf('firefox') === -1) {
+      document.removeEventListener('mousewheel', this.handleMouseWheel);
+    } else {
+      document.removeEventListener('DOMMouseScroll', this.handleMouseWheel);
+    }
+
+    // 手机触屏屏幕
+    document.removeEventListener('touchstart', this.handleTouchStart);
+    this.handleTouchEnd = utils.throttle(this.touchEnd, this, 500);
+    document.removeEventListener('touchend', this.handleTouchEnd);
+    document.removeEventListener('touchmove', this.handleTouchMove);
+
+    // 窗口尺寸变化时重置位置
+    this.handleNewPosition = utils.debounce(this.getNewPosition.bind(this), 200);
+    window.removeEventListener('resize', this.handleNewPosition);
   }
 }


### PR DESCRIPTION
在vue/react中使用时，初次进入页面（onMounted）的时候init会绑定事件，当离开页面事件没有销毁，下次再进入页面又会绑定事件。

因此会出现同一个事件会触发多次造成错误，增加了一个remove方法，离开页面的时候可手动销毁事件。

vue3 中使用方法示例：
```js
const pureFullPage = ref()
onMounted(() => {
  pureFullPage.value = new PureFullPage()
  pureFullPage.value.init()
})

onUnmounted(() => {
  pureFullPage.value?.remove()
})
```